### PR TITLE
API 3.0.0-ALPHA7 Fixes

### DIFF
--- a/src/Legoboy/Turrets/TurretsCommand.php
+++ b/src/Legoboy/Turrets/TurretsCommand.php
@@ -24,7 +24,7 @@ class TurretsCommand extends Command implements PluginIdentifiableCommand{
 		return $this->plugin;
 	}
 
-	public function execute(CommandSender $sender, $commandLabel, array $args){
+	public function execute(CommandSender $sender, $commandLabel, array $args) : bool{
 		if(count($args) > 0){
 			$subCommand = strtolower($args[0]);
 			if($subCommand === 'save'){


### PR DESCRIPTION
public function execute(CommandSender $sender, $commandLabel, array $args){

needs to be:

public function execute(CommandSender $sender, $commandLabel, array $args) : bool{

(API 3.0.0-ALPHA7 Requirement)